### PR TITLE
fix(impl-review): retry the staging download before the render check

### DIFF
--- a/.claude/skills/babysit-pipeline/SKILL.md
+++ b/.claude/skills/babysit-pipeline/SKILL.md
@@ -259,6 +259,16 @@ nothing failed.
   put the spec on `rescue_specs.txt`: the driver's dispatch
   auto-closes every open PR of the pair, so a regeneration fired while
   a repair is mid-flight throws that work away.
+- **A `Review: PR #N` run failing at "Verify both theme renders exist"
+  with staging complete is a lost download, not a missing render.** The
+  PR keeps no verdict label, so no watchdog case matches and the driver
+  waits an hour before calling the spec stalled. Check
+  `gs://anyplot-images/staging/<spec>/<lang>/<lib>/` — 18 objects means
+  the generate/repair upload was fine — then `gh workflow run
+  impl-review.yml -f pr_number=N` once, only when no `Review: PR #N`
+  run is active. The download step retries since the 2026-09-09 fix;
+  a repeat on the same PR after that means the staging folder really is
+  empty and the pair needs a fresh generate.
 - **A `Merge: PR #N` run that fails AFTER "Merge PR to main" leaves a
   silent hole: the squash is on main (metadata pointing at production
   URLs, the driver counts the pair as done) but the images are still in

--- a/.github/workflows/impl-review.yml
+++ b/.github/workflows/impl-review.yml
@@ -178,7 +178,22 @@ jobs:
           LANGUAGE: ${{ steps.lang.outputs.language }}
         run: |
           mkdir -p plot_images
-          gsutil -m cp "gs://anyplot-images/staging/${SPEC_ID}/${LANGUAGE}/${LIBRARY}/*" plot_images/ 2>/dev/null || true
+          # Retried: a single lost transfer used to be swallowed here (`2>/dev/null
+          # || true`), and the next step then failed on an empty directory with
+          # no label set — no watchdog case matches that, so the PR sat until
+          # someone re-dispatched the review by hand (#11360 on 2026-09-05,
+          # #11678 on 2026-09-09; staging was complete both times). Keep stderr:
+          # a transfer blip and a missing staging folder need different answers.
+          SRC="gs://anyplot-images/staging/${SPEC_ID}/${LANGUAGE}/${LIBRARY}/*"
+          for attempt in 1 2 3; do
+            if gsutil -m cp "$SRC" plot_images/ 2> /tmp/gsutil.err \
+               && [ -f plot_images/plot-light.png ] && [ -f plot_images/plot-dark.png ]; then
+              break
+            fi
+            GERR=$(head -c 300 /tmp/gsutil.err | tr '\n' ' ')
+            echo "::warning::staging download incomplete (attempt ${attempt}/3): ${GERR:-no error output}"
+            [ "$attempt" -lt 3 ] && sleep $((attempt * 10))
+          done
           ls -la plot_images/
 
       - name: Verify both theme renders exist

--- a/changelog.d/impl-review-staging-download-retry.md
+++ b/changelog.d/impl-review-staging-download-retry.md
@@ -7,4 +7,4 @@
   2026-09-09, staging complete both times). The download now tries three times with a short
   backoff, stops as soon as both theme renders are on disk, and keeps `gsutil`'s stderr in a
   warning per failed attempt, so a transfer blip heals in the same run and a genuinely empty
-  staging folder still fails loudly at the render check.
+  staging folder still fails loudly at the render check. (#11697)

--- a/changelog.d/impl-review-staging-download-retry.md
+++ b/changelog.d/impl-review-staging-download-retry.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- **`impl-review` retries the staging download instead of reviewing an empty directory** — the
+  step swallowed a lost `gsutil cp` (`2>/dev/null || true`), the render check right after it
+  then failed on nothing, and because that failure set no `ai-review-failed` label, no watchdog
+  case picked the PR up: it waited for a manual re-dispatch (#11360 on 2026-09-05, #11678 on
+  2026-09-09, staging complete both times). The download now tries three times with a short
+  backoff, stops as soon as both theme renders are on disk, and keeps `gsutil`'s stderr in a
+  warning per failed attempt, so a transfer blip heals in the same run and a genuinely empty
+  staging folder still fails loudly at the render check.


### PR DESCRIPTION
## Summary
- The "Download plot images from staging" step swallowed a lost `gsutil cp` (`2>/dev/null || true`); "Verify both theme renders exist" then failed on an empty directory, and since that failure sets no `ai-review-failed` label, no watchdog case matched — the PR waited for a manual re-dispatch. Seen twice with staging complete both times: #11360 (2026-09-05 03:56 UTC) and #11678 (2026-09-09 18:14 UTC).
- The download now tries three times with linear backoff, stops as soon as both theme PNGs are on disk, and surfaces `gsutil`'s stderr as a warning per failed attempt. A transfer blip heals in the same run; a genuinely empty staging folder still fails loudly at the unchanged render check.
- The `babysit-pipeline` skill gets the gotcha: how to tell a lost download from a missing render, and the one-shot re-dispatch.

## Plan
N/A

## Test plan
- [ ] Workflow YAML parses; the edited `run` block passes `bash -n`
- [ ] `uv run python -m tools.changelog check --base origin/main` passes
- [ ] After merge: the next review runs show "Found both theme renders" as before; a run that logs a `staging download incomplete (attempt 1/3)` warning still proceeds to the review
- [ ] Unchanged: an empty staging folder still fails at "Verify both theme renders exist"

Known gap: `.github/workflows/` changes have no local verification loop; only real review runs exercise the retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LfPAdJKa4JWzvsEUQZUuhs