### PR TITLE
infra(app): one nginx instance, concurrency 80

### DIFF
--- a/app/cloudbuild.yaml
+++ b/app/cloudbuild.yaml
@@ -83,15 +83,29 @@ steps:
       # Measurements behind this: #10812.
       - '--min-instances'
       - '0'
+      # max=1, with concurrency 80 below: one nginx is the whole capacity, and
+      # that is plenty — static files answer in milliseconds, memory sits at
+      # 15 MiB p99 of 512Mi, and the only requests that ever held a slot for
+      # long were bot requests proxied to the API while IT cold-started (~11 s;
+      # api/cloudbuild.yaml explains why that is gone). Under the old 15-slot
+      # limit one forged-UA burst on 2026-09-09 filled the instance and started
+      # two more, each a 0.26 s cold start nobody needed (50 AUTOSCALING starts
+      # in the ten days to 2026-09-10). A second instance was never for
+      # capacity; with max=1 a burst queues here for milliseconds instead of
+      # spreading over instances. Owner decision 2026-09-11: one instance per
+      # service in both projects.
       - '--max-instances'
-      - '3'
+      - '1'
       - '--port'
       - '8080'
       - '--execution-environment'
       - 'gen2'
       - '--cpu-throttling'
+      # 80, not 15: nginx serves static files and proxies the rest, and the API
+      # behind it caps its own work at 40 in flight. 15 was a default that
+      # turned every crawler burst into a scale-out (see --max-instances above).
       - '--concurrency'
-      - '15'
+      - '80'
       # Deploy WITHOUT routing traffic: the smoke step probes this revision on
       # its tag URL first, and only the promote step below shifts traffic — so
       # a broken nginx.conf never serves visitors or crawlers, not even between

--- a/app/cloudbuild.yaml
+++ b/app/cloudbuild.yaml
@@ -86,7 +86,7 @@ steps:
       # max=1, with concurrency 80 below: one nginx is the whole capacity, and
       # that is plenty — static files answer in milliseconds, memory sits at
       # 15 MiB p99 of 512Mi, and the only requests that ever held a slot for
-      # long were bot requests proxied to the API while IT cold-started (~11 s;
+      # long were bot requests proxied to the API while the API cold-started (~11 s;
       # api/cloudbuild.yaml explains why that is gone). Under the old 15-slot
       # limit one forged-UA burst on 2026-09-09 filled the instance and started
       # two more, each a 0.26 s cold start nobody needed (50 AUTOSCALING starts

--- a/changelog.d/app-single-instance.md
+++ b/changelog.d/app-single-instance.md
@@ -8,4 +8,4 @@
   proxied bot request open for as long as the API takes to answer. With the API
   on one warm instance those waits are milliseconds, and one nginx with 80 slots
   absorbs the burst without a cold start. `min-instances` stays 0; the API behind
-  it caps its own work at 40 in flight.
+  it caps its own work at 40 in flight. (#11829)

--- a/changelog.d/app-single-instance.md
+++ b/changelog.d/app-single-instance.md
@@ -1,0 +1,11 @@
+### Changed
+
+- **`anyplot-app` runs as a single instance with concurrency 80 (was max 3,
+  concurrency 15).** A static nginx never needed a second instance for capacity —
+  its files answer in milliseconds and it sits at 15 MiB of memory — yet every
+  crawler burst filled the 15 slots and started one or two more instances (50
+  AUTOSCALING starts in the ten days to 2026-09-10), because nginx holds a
+  proxied bot request open for as long as the API takes to answer. With the API
+  on one warm instance those waits are milliseconds, and one nginx with 80 slots
+  absorbs the burst without a cold start. `min-instances` stays 0; the API behind
+  it caps its own work at 40 in flight.


### PR DESCRIPTION
## Summary
- **`anyplot-app` runs as a single instance with concurrency 80** (was max 3, concurrency 15; `min-instances` stays 0). A static nginx never needed a second instance for capacity — its files answer in milliseconds and it sits at 15 MiB p99 of 512Mi — yet every crawler burst filled the 15 slots and started one or two more instances (50 AUTOSCALING starts in the ten days to 2026-09-10), because nginx holds a proxied bot request open for as long as the API takes to answer. One forged-UA burst on 2026-09-09 filled the instance and started two more. With the API on one warm instance (#11828) those waits are milliseconds, and one nginx with 80 slots absorbs the burst without a 0.26 s cold start.
- Owner decision 2026-09-11: one instance per service in both projects (the sibling PR in kurrentschrift does the same there). If 429s ever appear, max 2 is the next step.
- `docs/reference/performance.md` still says max 3 / concurrency 15 for the frontend after this PR: #11828 edits the same table row, so the row is updated in a follow-up once both have merged, to keep the two PRs from conflicting.

## Plan
N/A — measurements in the Todoist task "Nachprüfen: merkt jemand, dass anyplot-app auf null skaliert?" (closed 2026-09-10 with the numbers) and in #11828.

## Test plan
- [x] `app/cloudbuild.yaml` parses; the deploy step carries `--min-instances 0 --max-instances 1 --concurrency 80`
- [x] `uv run python -m tools.changelog check --base origin/main` passes
- [x] No image or nginx change: the app image and the origin-gate smoke in CI are unaffected; the candidate smoke in Cloud Build probes the new revision before traffic moves
- [ ] After merge: Cloud Build `deploy-app` green; `gcloud run revisions describe` on the promoted revision shows `maxScale 1`, `containerConcurrency 80`; then two weeks of `run.googleapis.com/request_count` by response_code (zero 429s expected) and instance-start logs (AUTOSCALING starts should stop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CELiZYpFBQc5bncjWXYrue