### PR TITLE
docs(performance): frontend row shows one instance, concurrency 80

### DIFF
--- a/changelog.d/performance-frontend-row.md
+++ b/changelog.d/performance-frontend-row.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- **`docs/reference/performance.md` shows the frontend at one instance with
+  concurrency 80.** #11828 and #11829 edited the same infrastructure table row
+  from different branches, so the frontend line still carried max-instances=3
+  and concurrency 15 after both had merged; it now matches `app/cloudbuild.yaml`.

--- a/docs/reference/performance.md
+++ b/docs/reference/performance.md
@@ -7,7 +7,7 @@ Backend API response time measurements for anyplot-backend (Cloud Run, europe-we
 | Component | Config | Notes |
 |-----------|--------|-------|
 | Cloud Run (backend) | 1 vCPU, 1Gi RAM, min-instances=1, max-instances=1, concurrency 40 | gen2, startup-cpu-boost=true. Single instance since 2026-09-10: every scale-out was a 9-13 s cold start that a live request paid for (see `api/cloudbuild.yaml`) |
-| Cloud Run (frontend) | 1 vCPU, 512Mi RAM, min-instances=0, max-instances=3, concurrency 15 | nginx serving SPA; scales to zero since 2026-08-29, crawler traffic keeps the instance alive |
+| Cloud Run (frontend) | 1 vCPU, 512Mi RAM, min-instances=0, max-instances=1, concurrency 80 | nginx serving SPA; scales to zero since 2026-08-29, crawler traffic keeps the instance alive; one instance since 2026-09-11 (see `app/cloudbuild.yaml`) |
 | Cloud SQL | `db-custom-1-3840`, PostgreSQL 18, PD-SSD 10GB | 1 vCPU, 3.75GB RAM; 3-year commitment until 2029-04-01 |
 | Cache | In-memory TTLCache, 86400s TTL (24h), max 1000 entries | Per-instance, stampede-protected, stale-while-revalidate |
 

--- a/docs/reference/performance.md
+++ b/docs/reference/performance.md
@@ -7,7 +7,7 @@ Backend API response time measurements for anyplot-backend (Cloud Run, europe-we
 | Component | Config | Notes |
 |-----------|--------|-------|
 | Cloud Run (backend) | 1 vCPU, 1Gi RAM, min-instances=1, max-instances=1, concurrency 40 | gen2, startup-cpu-boost=true. Single instance since 2026-09-10: every scale-out was a 9-13 s cold start that a live request paid for (see `api/cloudbuild.yaml`) |
-| Cloud Run (frontend) | 1 vCPU, 512Mi RAM, min-instances=0, max-instances=1, concurrency 80 | nginx serving SPA; scales to zero since 2026-08-29, crawler traffic keeps the instance alive; one instance since 2026-09-11 (see `app/cloudbuild.yaml`) |
+| Cloud Run (frontend) | 1 vCPU, 512Mi RAM, min-instances=0, max-instances=1, concurrency 80 | nginx serving SPA; scales to zero since 2026-08-29, crawler traffic keeps the instance alive; capped at one instance since 2026-09-11 (see `app/cloudbuild.yaml`) |
 | Cloud SQL | `db-custom-1-3840`, PostgreSQL 18, PD-SSD 10GB | 1 vCPU, 3.75GB RAM; 3-year commitment until 2029-04-01 |
 | Cache | In-memory TTLCache, 86400s TTL (24h), max 1000 entries | Per-instance, stampede-protected, stale-while-revalidate |
 


### PR DESCRIPTION
## Summary
- `docs/reference/performance.md`: the frontend row of the infrastructure table now says max-instances=1, concurrency 80, matching `app/cloudbuild.yaml` after #11829. #11828 and #11829 edited the same row from different branches, so this line was left behind on purpose to keep the two from conflicting.

## Plan
N/A

## Test plan
- [x] `uv run python -m tools.changelog check --base origin/main` passes
- [x] Docs-only change; no code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CELiZYpFBQc5bncjWXYrue